### PR TITLE
Fixes to ensure the correct group permissions for the libvirtd directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ADD supervisor.webvirtmgr.conf /etc/supervisor/conf.d/webvirtmgr.conf
 ADD gunicorn.conf.py /webvirtmgr/conf/gunicorn.conf.py
 
 ADD bootstrap.sh /webvirtmgr/bootstrap.sh
+ADD entrypoint.sh /webvirtmgr/entrypoint.sh
 
 RUN useradd webvirtmgr -g libvirtd -u 1010 -d /data/vm/ -s /sbin/nologin
 RUN chown webvirtmgr:libvirtd -R /webvirtmgr
@@ -27,4 +28,4 @@ VOLUME /data/vm
 
 EXPOSE 8080
 EXPOSE 6080
-CMD ["supervisord", "-n"]
+CMD ["/webvirtmgr/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ $ sudo chown -R webvirtmgr:webvirtmgr /data/vm
 ### Usage
 
 ```
-$ docker run -d -p 8080:8080 -p 6080:6080 --name webvirtmgr -v /data/vm:/data/vm primiano/docker-webvirtmgr
+$ LIBVIRT_GUID=`getent group libvirtd | cut -d":" -f3`
+$ docker run -d -p 8080:8080 -p 6080:6080 --name webvirtmgr -e LIBVIRTGID="$LIBVIRT_GIUD" -v /data/vm:/data/vm -v /var/run/libvirt:/var/run/libvirt primiano/docker-webvirtmgr
 ```
 
 ### libvirtd configuration on the host

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-if [ ! -f "/data/vm/webvirtmgr.sqlite3" ]; then
-
-chown webvirtmgr /var/run/libvirt/libvirt-sock
-/usr/bin/python /webvirtmgr/manage.py syncdb --noinput
-echo "from django.contrib.auth.models import User; User.objects.create_superuser('admin', 'admin@localhost', '1234')" | /usr/bin/python /webvirtmgr/manage.py shell
-
+if [ ! -f "/data/vm/webvirtmgr.sqlite3" ]; 
+then
+  sed -i s/108/$LIBVIRTGID/g /etc/passwd
+  sed -i s/108/$LIBVIRTGID/g /etc/group
+  /usr/bin/python /webvirtmgr/manage.py syncdb --noinput
+  echo "from django.contrib.auth.models import User; User.objects.create_superuser('admin', 'admin@localhost', '1234')" | /usr/bin/python /webvirtmgr/manage.py shell
 fi
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,8 +2,6 @@
 
 if [ ! -f "/data/vm/webvirtmgr.sqlite3" ]; 
 then
-  sed -i s/108/$LIBVIRTGID/g /etc/passwd
-  sed -i s/108/$LIBVIRTGID/g /etc/group
   /usr/bin/python /webvirtmgr/manage.py syncdb --noinput
   echo "from django.contrib.auth.models import User; User.objects.create_superuser('admin', 'admin@localhost', '1234')" | /usr/bin/python /webvirtmgr/manage.py shell
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Change the GID of the libvirtd group to match that of the host
+sed -i s/108/$LIBVIRTGID/g /etc/passwd
+sed -i s/108/$LIBVIRTGID/g /etc/group
+
+exec supervisord -n


### PR DESCRIPTION
I came up with these changes to ensure that the group ID for the libvirtd group in the container is the same as that on the host. After this it is trivial to add the host in webvirtmgr using the local socket fucntionality and hence, no changes to libvirt on the host are required.
